### PR TITLE
Ignore history path from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+history/* linguist-documentation


### PR DESCRIPTION
The language stats bar doesn't update when a specific branch is selected so this must be merged to take effect.